### PR TITLE
Add design-sync inputs for Petstore Web Components

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,25 @@
+# design-sync notes — petstore-web
+
+## Context
+- **This repo is a React _application_ (webpack app bundle), not a design-system library.** It has no library `dist/` build and no `.d.ts` exports — the converter runs in **synth-entry mode** from `src/`.
+- The "design system" here is **custom CSS** (`src/components/**/*.css`), not MUI. Components are plain HTML + CSS classes (e.g. `.pet-card`, `.btn-primary`, `.badge`, `.characteristic-tag`). MUI is only used trivially in `ButtonUsage.tsx` (not synced).
+- **Scope is deliberately narrow:** only the two clean, prop-driven presentational components — `PetCard` and `PetDetails`. Header (needs React Router), Footer (site chrome), PetShowcase (stateful container), ButtonUsage (trivial) were excluded by the user.
+- Sample data for previews: `src/data/samplePets.ts` (`samplePets: Pet[]`). Pet type: `src/types/Pet.ts`.
+
+## Components
+- `PetCard` (`src/components/pet/PetCard.tsx`) — prop: `pet: Pet`, `onViewDetails?`, `onAddToCart?`, `className?`. Plain card. Imports `./PetCard.css`.
+- `PetDetails` (`src/components/pet/PetDetails.tsx`) — prop: `pet: Pet`, `onClose?`, `onAddToCart?`, `onScheduleVisit?`, `className?`. **Overlay modal** (`.pet-details-overlay`) — needs `cardMode: single` + a viewport override to render inside the card. Imports `./PetDetails.css`.
+
+## Build / preview specifics
+- **Scoped entry:** the converter runs against a hand-written `.design-sync/entry.tsx` (passed as `--entry`) that re-exports only PetCard + PetDetails — this is what keeps scope to the two components. To add a component later, add an export there AND a `componentSrcMap` + `dtsPropsFor` entry.
+- **`dtsPropsFor` is hand-written** for both components: synth-entry mode parsed 0 `.d.ts` files, so auto-extraction fell back to `[key: string]: unknown`. The hand-written bodies inline the full `Pet` shape (keep them in sync with `src/types/Pet.ts`).
+- **PetDetails is a full-screen `position: fixed` overlay modal.** Its authored preview injects a scoped `<style>` (the `InlineModal` helper) that neutralizes the fixed/centered backdrop so the real modal markup flows inline, top-to-bottom, fully visible — the standard way to preview a dialog. Override: `cardMode: single`, `viewport: 1100x1500`. The component's own styles are otherwise untouched.
+- **Images:** previews use the real Unsplash URLs from `samplePets`. In headless capture they don't load, so PetCard/PetDetails fall back to the component's own emoji SVG placeholder — graceful and intended. In the live DS pane (with network) the real photos load.
+
+## Known render warns
+- None recorded — render check is clean (`bad` empty, no thin/variantsIdentical flags).
+
+## Re-sync risks
+- Synth-entry mode means `.d.ts` prop contracts are derived from `src/` TSX, not shipped types — weaker than a real library build. If a real component library is ever extracted, repoint at it.
+- Preview content is the real `samplePets` data inlined into authored `previews/*.tsx`; if the Pet shape changes, both the previews AND the `dtsPropsFor` inline Pet shape need updating.
+- PetDetails preview's `InlineModal` style override is tied to the component's current class names (`.pet-details-overlay`, `.pet-details-modal`). If those CSS class names change, the override silently stops applying and the preview reverts to the clipped centered-overlay framing.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,20 @@
+{
+  "projectId": "69f53fc3-43d9-4132-aa93-a91b8b74f270",
+  "pkg": "petstore-web",
+  "globalName": "PetstoreWeb",
+  "shape": "package",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "componentSrcMap": {
+    "PetCard": "src/components/pet/PetCard.tsx",
+    "PetDetails": "src/components/pet/PetDetails.tsx"
+  },
+  "dtsPropsFor": {
+    "PetCard": "/** The pet to render. */\npet: { id: string; name: string; species: string; breed: string; age: number; gender: \"Male\" | \"Female\"; price: number; description: string; imageUrl: string; isAvailable: boolean; characteristics: string[]; healthStatus: \"Excellent\" | \"Good\" | \"Fair\"; vaccinated: boolean; spayedNeutered: boolean; size: \"Small\" | \"Medium\" | \"Large\" | \"Extra Large\"; energyLevel: \"Low\" | \"Medium\" | \"High\"; goodWithKids: boolean; goodWithPets: boolean };\n/** Fired when the \"View Details\" button is clicked. */\nonViewDetails?: (pet: PetCardProps[\"pet\"]) => void;\n/** Fired when the \"Add to Cart\" button is clicked. */\nonAddToCart?: (pet: PetCardProps[\"pet\"]) => void;\n/** Extra class name appended to the card root element. */\nclassName?: string;",
+    "PetDetails": "/** The pet to render in the detail modal. */\npet: { id: string; name: string; species: string; breed: string; age: number; gender: \"Male\" | \"Female\"; price: number; description: string; imageUrl: string; isAvailable: boolean; characteristics: string[]; healthStatus: \"Excellent\" | \"Good\" | \"Fair\"; vaccinated: boolean; spayedNeutered: boolean; size: \"Small\" | \"Medium\" | \"Large\" | \"Extra Large\"; energyLevel: \"Low\" | \"Medium\" | \"High\"; goodWithKids: boolean; goodWithPets: boolean };\n/** Fired when the close (✕) button is clicked. */\nonClose?: () => void;\n/** Fired when the \"Add to Cart\" button is clicked. */\nonAddToCart?: (pet: PetDetailsProps[\"pet\"]) => void;\n/** Fired when the \"Schedule a Visit\" button is clicked. */\nonScheduleVisit?: (pet: PetDetailsProps[\"pet\"]) => void;\n/** Extra class name appended to the overlay root element. */\nclassName?: string;"
+  },
+  "overrides": {
+    "PetDetails": { "cardMode": "single", "viewport": "1100x1500" }
+  },
+  "readmeHeader": ".design-sync/conventions.md"
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,73 @@
+## Petstore Web — how to build with these components
+
+This is a small, **data-driven** component set extracted from the petstore-web app. There are two components, both in the `pet` group:
+
+- **`PetCard`** — a compact pet listing card for grids/lists.
+- **`PetDetails`** — a full detail view of a single pet, rendered as a **full-screen `position: fixed` overlay modal** (it paints over the whole viewport with a dark backdrop).
+
+### Setup — no provider, no theme
+
+Neither component needs a provider, context, router, or theme wrapper. Render them directly from `window.PetstoreWeb`. They bring their own styles (see below), so the only setup is loading the bundle + `styles.css`.
+
+```jsx
+const { PetCard } = window.PetstoreWeb;
+```
+
+### The styling idiom — styles ship with the components
+
+There is **no utility-class system and no style props.** Each component owns its complete markup and CSS class vocabulary, shipped in `_ds_bundle.css` (reached via `styles.css`). You do **not** add classes or theme tokens to style them — you style them by passing a well-formed `pet` object, and the component renders its own classes (e.g. `.pet-card`, `.btn-primary`, `.btn-secondary`, `.badge`, `.characteristic-tag`, `.pet-details-overlay`, `.pet-details-modal`). For your own surrounding layout (the grid these cards sit in, page chrome), use plain CSS/flex/grid — there is no DS layout primitive here.
+
+The single most important rule: **drive these components with data, not props-as-config.** The `pet` object is the design language. It must be a complete object of this shape (see `PetCard.d.ts` / `PetDetails.d.ts` for the exact contract):
+
+```ts
+{
+  id, name, species, breed, age, gender, price, description, imageUrl,
+  isAvailable, characteristics: string[], healthStatus, vaccinated,
+  spayedNeutered, size, energyLevel, goodWithKids, goodWithPets
+}
+```
+
+A few fields drive visible state automatically: `isAvailable: false` greys the card / shows a "Not Available" banner and hides the buy action; `species` selects the emoji; `vaccinated` / `spayedNeutered` / `goodWithKids` / `goodWithPets` toggle badges. If `imageUrl` fails to load, the component falls back to an emoji placeholder on its own.
+
+### Interactions
+
+Pass callbacks for user actions — the components render the buttons, you handle the events:
+
+- `PetCard`: `onViewDetails(pet)`, `onAddToCart(pet)`
+- `PetDetails`: `onClose()`, `onAddToCart(pet)`, `onScheduleVisit(pet)`
+
+The typical flow: a grid of `PetCard`s; clicking one's `onViewDetails` opens a `PetDetails` overlay for that pet; `onClose` dismisses it.
+
+### Where the truth lives
+
+- `styles.css` → `@import "./_ds_bundle.css"` — the complete component styles. Read `_ds_bundle.css` before assuming any visual detail.
+- `components/pet/PetCard/PetCard.d.ts` and `PetDetails.d.ts` — the exact prop contract.
+- `components/pet/<Name>/<Name>.prompt.md` — per-component usage.
+
+### One idiomatic example
+
+```jsx
+const { PetCard } = window.PetstoreWeb;
+
+const buddy = {
+  id: '1', name: 'Buddy', species: 'Dog', breed: 'Golden Retriever',
+  age: 2, gender: 'Male', price: 1200,
+  description: 'Friendly and energetic golden retriever.',
+  imageUrl: 'https://example.com/buddy.jpg',
+  isAvailable: true,
+  characteristics: ['Friendly', 'Energetic', 'Loyal'],
+  healthStatus: 'Excellent', vaccinated: true, spayedNeutered: true,
+  size: 'Large', energyLevel: 'High', goodWithKids: true, goodWithPets: true,
+};
+
+// Your own grid wrapper (plain CSS) holding DS cards:
+function PetGrid({ pets, onOpen }) {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill,minmax(280px,1fr))', gap: 24 }}>
+      {pets.map((p) => (
+        <PetCard key={p.id} pet={p} onViewDetails={onOpen} onAddToCart={() => {}} />
+      ))}
+    </div>
+  );
+}
+```

--- a/.design-sync/entry.tsx
+++ b/.design-sync/entry.tsx
@@ -1,0 +1,4 @@
+// Scoped design-sync entry: only the presentational, prop-driven components.
+// See .design-sync/NOTES.md for why scope is limited to these two.
+export { default as PetCard } from '../src/components/pet/PetCard';
+export { default as PetDetails } from '../src/components/pet/PetDetails';

--- a/.design-sync/previews/PetCard.tsx
+++ b/.design-sync/previews/PetCard.tsx
@@ -1,0 +1,89 @@
+// Authored design-sync preview for PetCard.
+// Content mirrors src/data/samplePets.ts so the cards look like the real app.
+import { PetCard } from 'petstore-web';
+
+const buddy = {
+  id: '1',
+  name: 'Buddy',
+  species: 'Dog',
+  breed: 'Golden Retriever',
+  age: 2,
+  gender: 'Male',
+  price: 1200,
+  description:
+    'Friendly and energetic golden retriever who loves playing fetch and swimming. Great with kids and other pets!',
+  imageUrl:
+    'https://images.unsplash.com/photo-1552053831-71594a27632d?w=400&h=300&fit=crop',
+  isAvailable: true,
+  characteristics: ['Friendly', 'Energetic', 'Loyal', 'Intelligent', 'Playful'],
+  healthStatus: 'Excellent',
+  vaccinated: true,
+  spayedNeutered: true,
+  size: 'Large',
+  energyLevel: 'High',
+  goodWithKids: true,
+  goodWithPets: true,
+};
+
+const luna = {
+  id: '2',
+  name: 'Luna',
+  species: 'Cat',
+  breed: 'Persian',
+  age: 1.5,
+  gender: 'Female',
+  price: 800,
+  description:
+    'Beautiful Persian cat with a calm and gentle temperament. Perfect for a quiet home environment.',
+  imageUrl:
+    'https://images.unsplash.com/photo-1514888286974-6c03e2ca1dba?w=400&h=300&fit=crop',
+  isAvailable: true,
+  characteristics: ['Calm', 'Gentle', 'Affectionate', 'Quiet'],
+  healthStatus: 'Excellent',
+  vaccinated: true,
+  spayedNeutered: true,
+  size: 'Medium',
+  energyLevel: 'Low',
+  goodWithKids: true,
+  goodWithPets: false,
+};
+
+const charlie = {
+  id: '3',
+  name: 'Charlie',
+  species: 'Bird',
+  breed: 'Cockatiel',
+  age: 0.5,
+  gender: 'Male',
+  price: 150,
+  description:
+    'Young cockatiel with beautiful plumage. Can learn to whistle and talk with proper training.',
+  imageUrl:
+    'https://images.unsplash.com/photo-1544923246-77307dd6db90?w=400&h=300&fit=crop',
+  isAvailable: false,
+  characteristics: ['Vocal', 'Social', 'Intelligent', 'Colorful'],
+  healthStatus: 'Good',
+  vaccinated: true,
+  spayedNeutered: false,
+  size: 'Small',
+  energyLevel: 'Medium',
+  goodWithKids: true,
+  goodWithPets: true,
+};
+
+const noop = () => {};
+
+/** An available dog with the full set of badges and actions. */
+export const Available = () => (
+  <PetCard pet={buddy} onViewDetails={noop} onAddToCart={noop} />
+);
+
+/** A calm cat — lower energy, different species emoji and badges. */
+export const CalmCat = () => (
+  <PetCard pet={luna} onViewDetails={noop} onAddToCart={noop} />
+);
+
+/** An unavailable pet: greyed overlay, no "Add to Cart" action. */
+export const Unavailable = () => (
+  <PetCard pet={charlie} onViewDetails={noop} onAddToCart={noop} />
+);

--- a/.design-sync/previews/PetDetails.tsx
+++ b/.design-sync/previews/PetDetails.tsx
@@ -1,0 +1,90 @@
+// Authored design-sync preview for PetDetails (full-screen overlay modal).
+// Rendered with cardMode:single + a tall viewport (see config overrides) so the
+// overlay paints inside the card. Content mirrors src/data/samplePets.ts.
+import { PetDetails } from 'petstore-web';
+
+const buddy = {
+  id: '1',
+  name: 'Buddy',
+  species: 'Dog',
+  breed: 'Golden Retriever',
+  age: 2,
+  gender: 'Male',
+  price: 1200,
+  description:
+    'Friendly and energetic golden retriever who loves playing fetch and swimming. Great with kids and other pets!',
+  imageUrl:
+    'https://images.unsplash.com/photo-1552053831-71594a27632d?w=400&h=300&fit=crop',
+  isAvailable: true,
+  characteristics: ['Friendly', 'Energetic', 'Loyal', 'Intelligent', 'Playful'],
+  healthStatus: 'Excellent',
+  vaccinated: true,
+  spayedNeutered: true,
+  size: 'Large',
+  energyLevel: 'High',
+  goodWithKids: true,
+  goodWithPets: true,
+};
+
+const charlie = {
+  id: '3',
+  name: 'Charlie',
+  species: 'Bird',
+  breed: 'Cockatiel',
+  age: 0.5,
+  gender: 'Male',
+  price: 150,
+  description:
+    'Young cockatiel with beautiful plumage. Can learn to whistle and talk with proper training.',
+  imageUrl:
+    'https://images.unsplash.com/photo-1544923246-77307dd6db90?w=400&h=300&fit=crop',
+  isAvailable: false,
+  characteristics: ['Vocal', 'Social', 'Intelligent', 'Colorful'],
+  healthStatus: 'Good',
+  vaccinated: true,
+  spayedNeutered: false,
+  size: 'Small',
+  energyLevel: 'Medium',
+  goodWithKids: true,
+  goodWithPets: true,
+};
+
+const noop = () => {};
+
+// PetDetails is a full-screen `position: fixed` overlay modal. For a static
+// preview card we neutralize the fixed/centered backdrop so the real modal
+// markup flows inline, top-to-bottom and fully visible (the standard way to
+// preview a dialog component). The component's own styles are otherwise intact.
+// Recorded in .design-sync/NOTES.md.
+const InlineModal = () => (
+  <>
+    <style>{`
+      .pet-details-overlay { position: static; padding: 0; background: transparent; display: block; }
+      .pet-details-modal { max-height: none; max-width: 1000px; margin: 0 auto; box-shadow: 0 10px 40px rgba(0,0,0,0.12); }
+    `}</style>
+    {null}
+  </>
+);
+
+/** Full detail view of an available pet: image carousel, info grid, health,
+ *  compatibility, and the Add-to-Cart / Schedule-a-Visit actions. */
+export const Available = () => (
+  <>
+    <InlineModal />
+    <PetDetails
+      pet={buddy}
+      onClose={noop}
+      onAddToCart={noop}
+      onScheduleVisit={noop}
+    />
+  </>
+);
+
+/** Detail view of an unavailable pet: shows the "Not Available" banner and the
+ *  "Notify When Available" action instead of Add-to-Cart. */
+export const Unavailable = () => (
+  <>
+    <InlineModal />
+    <PetDetails pet={charlie} onClose={noop} />
+  </>
+);

--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,8 @@ dist
 .vscode/settings.json
 .vscode/tasks.json
 .vscode/typescript.json
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules


### PR DESCRIPTION
Syncs **PetCard** and **PetDetails** to the **Petstore Web Components** Claude Design project (`69f53fc3-43d9-4132-aa93-a91b8b74f270`).

### Context
`petstore-web` is a React **application**, not a design-system library, so scope was deliberately narrowed to the two clean, prop-driven presentational components. The converter runs in **synth-entry mode** from a scoped entry (no library `dist`/`.d.ts` to consume).

### What's committed (durable sync inputs only — build output/caches are gitignored)
- `.design-sync/config.json` — package shape, scoped `componentSrcMap`, hand-written `dtsPropsFor` (synth-entry parsed 0 `.d.ts`), `PetDetails` overlay override, `readmeHeader`.
- `.design-sync/entry.tsx` — scoped 2-component entry.
- `.design-sync/previews/{PetCard,PetDetails}.tsx` — authored preview stories from `samplePets`.
- `.design-sync/conventions.md` — design-agent header.
- `.design-sync/NOTES.md` — re-sync notes and risks.
- `.gitignore` — ignore `.ds-sync/`, `ds-bundle/`, `.design-sync/.cache/` etc.

### Verification
- Converter validate clean: 2 components, real props in `.d.ts`, render check `bad: 0`.
- All 5 preview cells graded **good**; grades carried forward (durable).
- Upload verified: 18 files present in the project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)